### PR TITLE
Avoid URI::InvalidURIError

### DIFF
--- a/lib/first_click_free/helpers/referrer.rb
+++ b/lib/first_click_free/helpers/referrer.rb
@@ -18,7 +18,8 @@ module FirstClickFree
       def permitted_domain?
         return true if FirstClickFree.test_mode && params.key?(:google_referrer)
         request.try(:referrer) && FirstClickFree.permitted_domains.any? do |domain|
-          URI.parse(request.referrer).hostname =~ /#{domain}\Z/
+          encoded_url = URI.encode(request.referrer)
+          URI.parse(encoded_url).hostname =~ /#{domain}\Z/
         end
       end
     end


### PR DESCRIPTION
- 下記エラーに対応するため
```ruby
Started GET "/5089?utm_source=outbrain&utm_medium=na&utm_campaign=ferret1&utm_content=pc1_26_59" for 167.88.104.182 at 2016-11-15 11:14:15 +0900
Processing by ArticlesController#show as HTML
  Parameters: {"utm_source"=>"outbrain", "utm_medium"=>"na", "utm_campaign"=>"ferret1", "utm_content"=>"pc1_26_59", "seq"=>"5089"}
Rendering 500 with exception: bad URI(is not URI?): Resource id #2
---------- backtrace ----------
/home/ec2-user/.rbenv/versions/2.3.1/lib/ruby/2.3.0/uri/rfc3986_parser.rb:67:in
 `split'\n/home/ec2-user/.rbenv/versions/2.3.1/lib/ruby/2.3.0/uri/rfc3986_parser.rb:73:in
 `parse'\n/home/ec2-u
ser/.rbenv/versions/2.3.1/lib/ruby/2.3.0/uri/common.rb:227:in
 `parse'\n/var/www/ferret/shared/bundle/ruby/2.3.0/bundler/gems/first_click_free-3374dd298b7f/lib/first_click_free/helpers/refer
rer.rb:21:in
 `block in permitted_domain?'\n/var/www/ferret/shared/bundle/ruby/2.3.0/bundler/gems/first_click_free-3374dd298b7f/lib/first_click_free/helpers/referrer.rb:20:in
 `any?'\n/var/ww
w/ferret/shared/bundle/ruby/2.3.0/bundler/gems/first_click_free-3374dd298b7f/lib/first_click_free/helpers/referrer.rb:20:in
 `permitted_domain?'\n/var/www/ferret/shared/bundle/ruby/2.3.0/bun
dler/gems/first_click_free-3374dd298b7f/lib/first_click_free/concerns/controller.rb:79:in
 `record_or_reject_first_click_free!'
```

- これでなおるかは未確定。なので様子見したい。


## エラー箇所 コード

first_click_free 内
https://github.com/basicinc/first_click_free/blob/master/lib/first_click_free/helpers/referrer.rb#L21


## 対応方法 参考

- `encoded_url = URI.encode(url)` が要るかもしれない
http://stackoverflow.com/questions/15700784/how-to-fix-bad-uri-is-not-uri